### PR TITLE
fix: Splits groups on _(

### DIFF
--- a/R/get_functional_groups.R
+++ b/R/get_functional_groups.R
@@ -8,24 +8,59 @@ utils::globalVariables(c("V1", "V2"))
 #' from the EwE output. The functional group names come from the basic
 #' estimates file.
 #'
+#' @details
+#' This function is for convenience only, it is not required by the package.
+#' Using it to generate the functional group names from a `basic_estimates.csv`
+#' file lessens the burden on you but we realize that the function will not
+#' work for every ecosystem model. It does work for many common naming
+#' conventions, including species names followed by numeric age groups, plus
+#' groups, ranges, and a small number of text suffixes such as `"juv"` and
+#' `"adult"`. However, functional group names in real EwE models are not always
+#' consistent. If your model uses names that cannot be parsed correctly, you
+#' can create the functional group tibble yourself and pass that tibble to
+#' functions such as [load_csv_ewe()].
+#'
+#' A custom functional group tibble must contain one row for each functional
+#' group in the model and the same four columns returned by this function. See
+#' the return section for more details on the columns. To create the last
+#' column, `functional_group_snake_case`, consider calling
+#' [split_functional_groups()] on the original names and then manually edit
+#' `species` and `group` where needed.
+#'
+#' The custom tibble should be checked before it is used in model-loading
+#' functions. In particular, confirm that `functional_group` has no missing
+#' values, that every functional group name is unique, that
+#' `functional_group_snake_case` is unique, and that the number of rows equals
+#' the number of living and non-living groups in the EwE output files you are
+#' about to load. If those columns are misaligned, downstream data can be read
+#' into the wrong functional group. When in doubt, start with the output of
+#' `get_functional_groups()` or [split_functional_groups()], inspect the result,
+#' and then replace only the rows that were parsed incorrectly.
+#'
 #' @param file_path The path to the EwE file.
 #' @return
 #' A tibble with the following columns:
 #' \itemize{
-#'   \item function_group. The full functional group name from the model. This
-#'         column is helpful for error checking and debugging.
-#'   \item species. The species name from the functional group name. This
-#'         column should only contain text strings and no numbers or special
-#'         characters. There will potentially be multiple rows with the same
-#'         species name because there can be multiple age groups for a given
-#'         species.
-#'   \item group. The group name as a string. This column can contain digits,
-#'         special characters, and text strings. It is used to
-#'         delineate the group within a species. Not all species will have
-#'         multiple groups.
-#'   \item functional_group_snake_case. A standardized version of the functional
-#'         group name. The functional_group is converted to lowercase and swaps 
-#'         spaces or hyphens for underscores.
+#'   \item `functional_group`: The exact functional group name used by EwE.
+#'         These values should match the names and order expected by the EwE
+#'         output files that you will load later. Keep this column exact to
+#'         the original EwE text as possible because it is the audit trail back
+#'         to the model.
+#'   \item `species`: The biological or conceptual species/group name after
+#'         removing any age, stage, size, or other within-species suffix. For
+#'         example, if EwE has `"King mackerel (0-1yr)"` and
+#'         `"King mackerel (1+yr)"`, both rows should usually have
+#'         `"King mackerel"` in `species`.
+#'   \item `group`: the age, stage, size, or other suffix within `species`.
+#'         Use a character value such as `"0-1yr"`, `"1+yr"`, `"juvenile"`, or
+#'         `"adult"` when a functional group is one of several groups for the
+#'         same species. Use `NA_character_` when the functional group does not
+#'         have a within-species suffix. It is used to delineate the group
+#'         within a species. Not all species will have multiple groups.
+#'   \item `functional_group_snake_case`: A unique, syntactically convenient
+#'         name that can be used as a column name in downstream output. These
+#'         names should be lowercase, should not contain spaces or parentheses,
+#'         and should be unique across rows.
 #' }
 #' @export
 #' @examples
@@ -33,6 +68,24 @@ utils::globalVariables(c("V1", "V2"))
 #'   file_path = fs::path(
 #'     system.file("extdata", package = "ecosystemom"),
 #'     "ewe_ecosim_with_environmental_data_nwatlantic", "basic_estimates.csv"
+#'   )
+#' )
+#'
+#' # If the automatic parser does not work for your naming convention, create
+#' # the functional group tibble yourself. This object can be supplied anywhere
+#' # ecosystemom asks for `functional_groups`.
+#' functional_groups <- tibble::tibble(
+#'   functional_group = c(
+#'     "King mackerel_(0-1yr)",
+#'     "King mackerel_(1+yr)",
+#'     "Detritus"
+#'   ),
+#'   species = c("King mackerel", "King mackerel", "Detritus"),
+#'   group = c("0-1yr", "1+yr", NA_character_),
+#'   functional_group_snake_case = c(
+#'     "king_mackerel_0_1yr",
+#'     "king_mackerel_1_plusyr",
+#'     "detritus"
 #'   )
 #' )
 get_functional_groups <- function(file_path) {

--- a/R/split_functional_groups.R
+++ b/R/split_functional_groups.R
@@ -47,6 +47,8 @@ split_functional_groups <- function(x) {
     # split digits separated by an underscore into digits separated by a dash
     # e.g., 1_2 becomes 1-2
     gsub(pattern = "([[:digit:]])_([[:digit:]])", replacement = "\\1-\\2") |>
+    # Treat underscores before parenthesized suffixes as separators
+    gsub(pattern = "_\\(", replacement = " (") |>
     # Parentheses are sometimes used around age/group suffixes in EwE outputs
     # (e.g., "King mackerel (0-1yr)"); strip wrappers before parsing.
     gsub(pattern = "[()]", replacement = "")

--- a/man/get_functional_groups.Rd
+++ b/man/get_functional_groups.Rd
@@ -12,20 +12,26 @@ get_functional_groups(file_path)
 \value{
 A tibble with the following columns:
 \itemize{
-\item function_group. The full functional group name from the model. This
-column is helpful for error checking and debugging.
-\item species. The species name from the functional group name. This
-column should only contain text strings and no numbers or special
-characters. There will potentially be multiple rows with the same
-species name because there can be multiple age groups for a given
-species.
-\item group. The group name as a string. This column can contain digits,
-special characters, and text strings. It is used to
-delineate the group within a species. Not all species will have
-multiple groups.
-\item functional_group_snake_case. A standardized version of the functional
-group name. The functional_group is converted to lowercase and swaps
-spaces or hyphens for underscores.
+\item \code{functional_group}: The exact functional group name used by EwE.
+These values should match the names and order expected by the EwE
+output files that you will load later. Keep this column exact to
+the original EwE text as possible because it is the audit trail back
+to the model.
+\item \code{species}: The biological or conceptual species/group name after
+removing any age, stage, size, or other within-species suffix. For
+example, if EwE has \code{"King mackerel (0-1yr)"} and
+\code{"King mackerel (1+yr)"}, both rows should usually have
+\code{"King mackerel"} in \code{species}.
+\item \code{group}: the age, stage, size, or other suffix within \code{species}.
+Use a character value such as \code{"0-1yr"}, \code{"1+yr"}, \code{"juvenile"}, or
+\code{"adult"} when a functional group is one of several groups for the
+same species. Use \code{NA_character_} when the functional group does not
+have a within-species suffix. It is used to delineate the group
+within a species. Not all species will have multiple groups.
+\item \code{functional_group_snake_case}: A unique, syntactically convenient
+name that can be used as a column name in downstream output. These
+names should be lowercase, should not contain spaces or parentheses,
+and should be unique across rows.
 }
 }
 \description{
@@ -34,11 +40,58 @@ an EwE model, and thus, this function is a way to get them automatically
 from the EwE output. The functional group names come from the basic
 estimates file.
 }
+\details{
+This function is for convenience only, it is not required by the package.
+Using it to generate the functional group names from a \code{basic_estimates.csv}
+file lessens the burden on you but we realize that the function will not
+work for every ecosystem model. It does work for many common naming
+conventions, including species names followed by numeric age groups, plus
+groups, ranges, and a small number of text suffixes such as \code{"juv"} and
+\code{"adult"}. However, functional group names in real EwE models are not always
+consistent. If your model uses names that cannot be parsed correctly, you
+can create the functional group tibble yourself and pass that tibble to
+functions such as \code{\link[=load_csv_ewe]{load_csv_ewe()}}.
+
+A custom functional group tibble must contain one row for each functional
+group in the model and the same four columns returned by this function. See
+the return section for more details on the columns. To create the last
+column, \code{functional_group_snake_case}, consider calling
+\code{\link[=split_functional_groups]{split_functional_groups()}} on the original names and then manually edit
+\code{species} and \code{group} where needed.
+
+The custom tibble should be checked before it is used in model-loading
+functions. In particular, confirm that \code{functional_group} has no missing
+values, that every functional group name is unique, that
+\code{functional_group_snake_case} is unique, and that the number of rows equals
+the number of living and non-living groups in the EwE output files you are
+about to load. If those columns are misaligned, downstream data can be read
+into the wrong functional group. When in doubt, start with the output of
+\code{get_functional_groups()} or \code{\link[=split_functional_groups]{split_functional_groups()}}, inspect the result,
+and then replace only the rows that were parsed incorrectly.
+}
 \examples{
 get_functional_groups(
   file_path = fs::path(
     system.file("extdata", package = "ecosystemom"),
     "ewe_ecosim_with_environmental_data_nwatlantic", "basic_estimates.csv"
+  )
+)
+
+# If the automatic parser does not work for your naming convention, create
+# the functional group tibble yourself. This object can be supplied anywhere
+# ecosystemom asks for `functional_groups`.
+functional_groups <- tibble::tibble(
+  functional_group = c(
+    "King mackerel_(0-1yr)",
+    "King mackerel_(1+yr)",
+    "Detritus"
+  ),
+  species = c("King mackerel", "King mackerel", "Detritus"),
+  group = c("0-1yr", "1+yr", NA_character_),
+  functional_group_snake_case = c(
+    "king_mackerel_0_1yr",
+    "king_mackerel_1_plusyr",
+    "detritus"
   )
 )
 }

--- a/tests/testthat/test-split_functional_groups.R
+++ b/tests/testthat/test-split_functional_groups.R
@@ -58,13 +58,19 @@ test_that("split_functional_groups() works with correct inputs", {
   expect_equal(
     object = split_functional_groups(c(
       "King mackerel (0-1yr)",
+      "King mackerel_(0-1yr)",
       "King mackerel (1+yr)"
     )),
     expected = tibble::tibble(
-      functional_group = c("King mackerel (0-1yr)", "King mackerel (1+yr)"),
-      species = c("King mackerel", "King mackerel"),
-      group = c("0-1yr", "1+yr"),
+      functional_group = c(
+        "King mackerel (0-1yr)",
+        "King mackerel_(0-1yr)",
+        "King mackerel (1+yr)"
+      ),
+      species = rep("King mackerel", 3),
+      group = c("0-1yr", "0-1yr", "1+yr"),
       functional_group_snake_case = c(
+        "king_mackerel_0_1yr",
         "king_mackerel_0_1yr",
         "king_mackerel_1_plusyr"
       )


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allow for splitting of x*_(y*) where the underscore precedes a (
* Added documentation for `get_functional_groups()` for when the function doesn't work for your EWE model.

# How have you implemented the solution?
* Added `gsub(pattern = "_\\(", replacement = " (") |>`
* Added an example and several paragraphs on what to do

# Does the PR impact any other area of the project, maybe another repo?
* No
Close #18
Close #22