### PR TITLE
Removes Rstudio from container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,12 +11,7 @@
     "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
     "packages": "cli,covr,devtools,dplyr,DT,ggplot2,htmltools,kableExtra,spelling,tibble,tidyr,usethis",
     "installSystemRequirements": true
-    },
-    // option to run rstudio. you can type rserver into the command line to
-    // get an session going (opens on a port, that you can open as a 
-    // separate browser window).
-    // more details: https://github.com/rocker-org/devcontainer-features/blob/main/src/rstudio-server/README.md
-    "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {}
+    }
   },
 
 	// Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
Copying what was done in FIMS by @Bai-Li-NOAA

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allow the devcontainer to work

# How have you implemented the solution?
* Removes Rstudio from devcontainer.json

# Does the PR impact any other area of the project, maybe another repo?
* 
